### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 ReactiveOps Inc
+# Copyright 2019 FairwindsOps Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 FROM openjdk:8-slim
 
 LABEL license=Apache-2.0
-LABEL maintainer=ReactiveOps
+LABEL maintainer=Fairwinds
 
 # Install tools
 RUN apt-get update \

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017, Reactive Ops Inc.
+   Copyright 2017, FairwindsOps Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/deploy/build.config
+++ b/deploy/build.config
@@ -1,4 +1,4 @@
-# Copyright 2019 ReactiveOps Inc
+# Copyright 2019 FairwindsOps Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remaining mentions: 
```
./deploy/build.config:EXTERNAL_REGISTRY_BASE_DOMAIN=quay.io/reactiveops
./.circleci/config.yml:      - image: quay.io/reactiveops/ci-images:v7-alpine
./.circleci/config.yml:            docker login -u="reactiveops+circleci" -p="${quay_token}" quay.io
```